### PR TITLE
feat: add pumpWidget callback to goldenTest

### DIFF
--- a/lib/src/golden_test.dart
+++ b/lib/src/golden_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:alchemist/alchemist.dart';
 import 'package:alchemist/src/alchemist_test_variant.dart';
+import 'package:alchemist/src/golden_test_adapter.dart';
 import 'package:alchemist/src/golden_test_runner.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -129,6 +130,7 @@ Future<void> goldenTest(
   double textScaleFactor = 1.0,
   BoxConstraints constraints = const BoxConstraints(),
   PumpAction pumpBeforeTest = onlyPumpAndSettle,
+  PumpWidget pumpWidget = onlyPumpWidget,
   Interaction? whilePerforming,
   required ValueGetter<Widget> builder,
 }) async {
@@ -170,6 +172,7 @@ Future<void> goldenTest(
         constraints: constraints,
         theme: goldensConfig.theme ?? config.theme ?? ThemeData.light(),
         pumpBeforeTest: pumpBeforeTest,
+        pumpWidget: pumpWidget,
         whilePerforming: whilePerforming,
       );
     },

--- a/lib/src/golden_test_adapter.dart
+++ b/lib/src/golden_test_adapter.dart
@@ -35,6 +35,9 @@ typedef GoldenFileExpectation = MatchesGoldenFileInvocation<void> Function(
   Object,
 );
 
+/// A function used to render a given [Widget].
+typedef PumpWidget = Future<void> Function(WidgetTester tester, Widget widget);
+
 /// Default golden file expectation function.
 // ignore: prefer_function_declarations_over_variables
 GoldenFileExpectation defaultGoldenFileExpectation =
@@ -163,6 +166,7 @@ abstract class GoldenTestAdapter {
     required ThemeData theme,
     required Widget widget,
     required PumpAction pumpBeforeTest,
+    required PumpWidget pumpWidget,
   });
 
   /// Generates an image of the widget at the given [finder] with all text
@@ -223,6 +227,7 @@ class FlutterGoldenTestAdapter extends GoldenTestAdapter {
     required ThemeData theme,
     required Widget widget,
     required PumpAction pumpBeforeTest,
+    required PumpWidget pumpWidget,
   }) async {
     final initialSize = Size(
       constraints.hasBoundedWidth ? constraints.maxWidth : 2000,
@@ -234,7 +239,8 @@ class FlutterGoldenTestAdapter extends GoldenTestAdapter {
     tester.binding.window.devicePixelRatioTestValue = 1.0;
     tester.binding.window.textScaleFactorTestValue = textScaleFactor;
 
-    await tester.pumpWidget(
+    await pumpWidget(
+      tester,
       MaterialApp(
         key: rootKey,
         theme: theme.stripTextPackages(),

--- a/lib/src/golden_test_runner.dart
+++ b/lib/src/golden_test_runner.dart
@@ -41,6 +41,7 @@ abstract class GoldenTestRunner {
     BoxConstraints constraints = const BoxConstraints(),
     ThemeData? theme,
     PumpAction pumpBeforeTest = onlyPumpAndSettle,
+    PumpWidget pumpWidget = onlyPumpWidget,
     Interaction? whilePerforming,
   });
 }
@@ -65,6 +66,7 @@ class FlutterGoldenTestRunner extends GoldenTestRunner {
     BoxConstraints constraints = const BoxConstraints(),
     ThemeData? theme,
     PumpAction pumpBeforeTest = onlyPumpAndSettle,
+    PumpWidget pumpWidget = onlyPumpWidget,
     Interaction? whilePerforming,
   }) async {
     assert(
@@ -85,6 +87,8 @@ class FlutterGoldenTestRunner extends GoldenTestRunner {
         textScaleFactor: textScaleFactor,
         constraints: constraints,
         pumpBeforeTest: pumpBeforeTest,
+        pumpWidget: pumpWidget,
+        widget: widget,
         theme: themeData.copyWith(
           textTheme: obscureText
               ? themeData.textTheme.apply(
@@ -92,7 +96,6 @@ class FlutterGoldenTestRunner extends GoldenTestRunner {
                 )
               : themeData.textTheme,
         ),
-        widget: widget,
       );
 
       AsyncCallback? cleanup;

--- a/lib/src/pumps.dart
+++ b/lib/src/pumps.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// the widget tree before the golden test is compared or generated.
 typedef PumpAction = Future<void> Function(WidgetTester tester);
 
-/// Returns a custom pump action that pumps the widget tree [n] times before
+/// Returns a custom [PumpAction] that pumps the widget tree [n] times before
 /// golden evaluation.
 ///
 /// See [PumpAction] for more details.
@@ -20,19 +20,27 @@ PumpAction pumpNTimes(int n, [Duration? duration]) {
   };
 }
 
-/// A custom pump action that pumps the widget tree once before golden
+/// A custom [PumpAction] that pumps the widget tree once before golden
 /// evaluation.
 ///
 /// See [PumpAction] for more details.
 final pumpOnce = pumpNTimes(1);
 
-/// A custom pump action that pumps and settles the widget tree before golden
+/// A custom [PumpAction] that pumps and settles the widget tree before golden
 /// evaluation.
 ///
 /// See [PumpAction] for more details.
 Future<void> onlyPumpAndSettle(WidgetTester tester) => tester.pumpAndSettle();
 
-/// A custom pump action to ensure that the images for all [Image],
+/// A custom [PumpAction] that pumps the widget tree before golden
+/// evaluation.
+///
+/// See [PumpAction] for more details.
+Future<void> onlyPumpWidget(WidgetTester tester, Widget widget) {
+  return tester.pumpWidget(widget);
+}
+
+/// A custom [PumpAction] to ensure that the images for all [Image],
 /// [FadeInImage], and [DecoratedBox] widgets are loaded before the golden file
 /// is generated.
 ///

--- a/test/src/golden_test_adapter_test.dart
+++ b/test/src/golden_test_adapter_test.dart
@@ -215,6 +215,7 @@ void main() {
             constraints: const BoxConstraints(),
             theme: ThemeData.light(),
             pumpBeforeTest: onlyPumpAndSettle,
+            pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
           );
 
@@ -236,6 +237,7 @@ void main() {
             constraints: BoxConstraints.tight(providedSize),
             theme: ThemeData.light(),
             pumpBeforeTest: onlyPumpAndSettle,
+            pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
           );
 
@@ -260,6 +262,7 @@ void main() {
             constraints: const BoxConstraints(),
             theme: ThemeData.light(),
             pumpBeforeTest: onlyPumpAndSettle,
+            pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
           );
 
@@ -291,6 +294,7 @@ void main() {
             ),
             theme: ThemeData.light(),
             pumpBeforeTest: onlyPumpAndSettle,
+            pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
           );
 
@@ -332,6 +336,7 @@ void main() {
             ),
             theme: ThemeData.light(),
             pumpBeforeTest: onlyPumpAndSettle,
+            pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
           );
 
@@ -349,6 +354,7 @@ void main() {
           constraints: const BoxConstraints(),
           theme: ThemeData.light(),
           pumpBeforeTest: onlyPumpAndSettle,
+          pumpWidget: onlyPumpWidget,
           widget: buildGroup(),
         );
 
@@ -374,6 +380,7 @@ void main() {
             constraints: const BoxConstraints(),
             theme: theme,
             pumpBeforeTest: onlyPumpAndSettle,
+            pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
           );
 
@@ -414,10 +421,26 @@ void main() {
           constraints: const BoxConstraints(),
           theme: ThemeData.light(),
           pumpBeforeTest: (_) async => pumpBeforeTestCalled = true,
+          pumpWidget: onlyPumpWidget,
           widget: buildGroup(),
         );
 
         expect(pumpBeforeTestCalled, isTrue);
+      });
+
+      testWidgets('calls the provided pumpWidget', (tester) async {
+        var pumpWidgetCalled = false;
+        await adapter.pumpGoldenTest(
+          tester: tester,
+          textScaleFactor: 2,
+          constraints: const BoxConstraints(),
+          theme: ThemeData.light(),
+          pumpBeforeTest: onlyPumpAndSettle,
+          pumpWidget: (_, __) async => pumpWidgetCalled = true,
+          widget: buildGroup(),
+        );
+
+        expect(pumpWidgetCalled, isTrue);
       });
     });
   });

--- a/test/src/golden_test_runner_test.dart
+++ b/test/src/golden_test_runner_test.dart
@@ -87,6 +87,7 @@ void main() {
           constraints: any(named: 'constraints'),
           theme: any(named: 'theme'),
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
+          pumpWidget: any(named: 'pumpWidget'),
           widget: any(named: 'widget'),
         ),
       ).thenAnswer((_) async {});
@@ -152,6 +153,7 @@ void main() {
           constraints: any(named: 'constraints'),
           theme: captureAny(named: 'theme'),
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
+          pumpWidget: any(named: 'pumpWidget'),
           widget: any(named: 'widget'),
         ),
       ).captured.first as ThemeData;
@@ -195,6 +197,7 @@ void main() {
           constraints: any(named: 'constraints'),
           theme: captureAny(named: 'theme'),
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
+          pumpWidget: any(named: 'pumpWidget'),
           widget: any(named: 'widget'),
         ),
       ).captured.first as ThemeData;

--- a/test/src/golden_test_test.dart
+++ b/test/src/golden_test_test.dart
@@ -40,6 +40,7 @@ class FakeGoldenTestAdapter extends Mock implements GoldenTestAdapter {
     required BoxConstraints constraints,
     required ThemeData theme,
     required PumpAction pumpBeforeTest,
+    required PumpWidget pumpWidget,
     required Widget widget,
   }) {
     return Future.value();
@@ -107,6 +108,7 @@ void main() {
           constraints: any(named: 'constraints'),
           theme: any(named: 'theme'),
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
+          pumpWidget: any(named: 'pumpWidget'),
           whilePerforming: any(named: 'whilePerforming'),
         ),
       ).thenAnswer((_) async {});
@@ -168,6 +170,7 @@ void main() {
           textScaleFactor: any(named: 'textScaleFactor'),
           theme: ciTheme,
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
+          pumpWidget: any(named: 'pumpWidget'),
           whilePerforming: any(named: 'whilePerforming'),
         ),
       ).called(1);
@@ -184,6 +187,7 @@ void main() {
           constraints: any(named: 'constraints'),
           theme: alchemistTheme,
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
+          pumpWidget: any(named: 'pumpWidget'),
           whilePerforming: any(named: 'whilePerforming'),
         ),
       );


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Adds a `pumpWidget` callback to the `goldenTest` function to allow developers to call `tester.pumpWidget` in a custom way.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
