### PR TITLE
fix:  Use `home`  instead of `builder` when pumpWidget in `GoldenTestAdapter.pumpGoldenTest`

### DIFF
--- a/lib/src/golden_test_adapter.dart
+++ b/lib/src/golden_test_adapter.dart
@@ -243,25 +243,23 @@ class FlutterGoldenTestAdapter extends GoldenTestAdapter {
         theme: theme.stripTextPackages(),
         debugShowCheckedModeBanner: false,
         supportedLocales: const [Locale('en')],
-        builder: (context, _) {
-          return DefaultAssetBundle(
-            bundle: TestAssetBundle(),
-            child: Material(
-              type: MaterialType.transparency,
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: ColoredBox(
-                  color: theme.colorScheme.background,
-                  child: Padding(
-                    key: childKey,
-                    padding: const EdgeInsets.all(8),
-                    child: widget,
-                  ),
+        home: DefaultAssetBundle(
+          bundle: TestAssetBundle(),
+          child: Material(
+            type: MaterialType.transparency,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: ColoredBox(
+                color: theme.colorScheme.background,
+                child: Padding(
+                  key: childKey,
+                  padding: const EdgeInsets.all(8),
+                  child: widget,
                 ),
               ),
             ),
-          );
-        },
+          ),
+        ),
       ),
     );
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

### Issue

With [0.3.2](https://github.com/Betterment/alchemist/releases/tag/v0.3.2), it not show me the `image` well when running with `goldenTest`. The result is:
<img width="483" alt="Screen Shot 2022-04-14 at 17 59 13" src="https://user-images.githubusercontent.com/19393071/163351217-939730aa-8263-44c5-8350-f005b776af7d.png">

Here is my test with current released version: https://github.com/HevaWu/TestAlchemist/commit/325db8a6c9404e842b7e86d6df061baef4e645c4

```dart
// widget
class IconWithText extends StatelessWidget {
  const IconWithText({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Container(
      color: Colors.white,
      height: 200,
      child: Padding(
        padding: const EdgeInsets.all(8.0),
        child: Column(
          children: [
            Image.asset(
              'assets/test.png',
              width: 64,
              height: 64,
              color: Colors.red,
            ),
            const SizedBox(
              height: 10.0,
            ),
            const Text(
              'Test Label',
              style: TextStyle(
                fontSize: 16.0,
                fontWeight: FontWeight.bold,
                color: Colors.orange,
              ),
            ),
          ],
        ),
      ),
    );
  }
}

// test function
void main() {
  goldenTest(
    'Golden Test',
    fileName: 'golden',
    pumpBeforeTest: precacheImages,
    builder: () => GoldenTestGroup(
      children: [
        GoldenTestScenario(
          name: 'normal',
          child: const IconWithText(),
        ),
      ],
    ),
  );
}
```

### My Suggestion

From Flutter's doc,  https://api.flutter.dev/flutter/widgets/DefaultAssetBundle-class.html
I notice we should use `home`  instead `build` at `pumpWidget.MaterialApp`, for showing image icon properly

After switch to use `home`, it can show me image well now.  
<img width="656" alt="Screen Shot 2022-04-14 at 18 07 05" src="https://user-images.githubusercontent.com/19393071/163352648-7e7e946a-dbea-4c1d-8ea3-a35f07544862.png">

Here is my testing code:
https://github.com/HevaWu/TestAlchemist/commit/ed93fdcb094425c529f8dda8cabc17977be01cba


Though I could solve it by making my own `GoldenTestAdapter`, I would like to see if we can directly update inside the source code. 
If no, please feel free to close this PR. 😄 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
