### PR TITLE
Feat/core widget wrapper

### DIFF
--- a/lib/src/golden_test.dart
+++ b/lib/src/golden_test.dart
@@ -8,7 +8,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 
-/// The core wrapper of the alchemist
+/// The CoreWidgetWrapper function, used for wrapping the base of golden test 
+/// and replacing the default MaterialApp wrapper
 typedef CoreWidgetWrapper = Widget Function(Widget child, Key? key);
 
 /// Default golden test runner which uses the flutter test framework.
@@ -72,6 +73,10 @@ Future<void> loadFonts() async {
 /// The [fileName] is the name of the file that will be used to store the
 /// golden image under the `goldens` directory. This name should be unique, and
 /// may not contain an extension (such as `.png`).
+/// 
+/// The [coreWrapper] is [CoreWidgetWrapper] function, which wraps 
+/// the base of the golden test. If not null, it replaces default 
+/// MaterialApp wrapper. If null, the default MaterialApp wrapper will be used.
 ///
 /// The provided [builder] builds the widget under test.
 /// Usually, it creates multiple scenarios using [GoldenTestGroup]

--- a/lib/src/golden_test.dart
+++ b/lib/src/golden_test.dart
@@ -8,6 +8,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 
+/// The core wrapper of the alchemist
+typedef CoreWidgetWrapper = Widget Function(Widget child, Key? key);
+
 /// Default golden test runner which uses the flutter test framework.
 const defaultGoldenTestRunner = FlutterGoldenTestRunner();
 GoldenTestRunner _goldenTestRunner = defaultGoldenTestRunner;
@@ -124,6 +127,7 @@ Future<void> loadFonts() async {
 Future<void> goldenTest(
   String description, {
   required String fileName,
+  CoreWidgetWrapper? coreWrapper,
   bool skip = false,
   List<String> tags = const ['golden'],
   double textScaleFactor = 1.0,
@@ -163,6 +167,7 @@ Future<void> goldenTest(
           fileName,
           goldensConfig.environmentName,
         ),
+        coreWrapper: coreWrapper,
         widget: builder(),
         forceUpdate: config.forceUpdateGoldenFiles,
         obscureText: goldensConfig.obscureText,

--- a/lib/src/golden_test_adapter.dart
+++ b/lib/src/golden_test_adapter.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
+import 'package:alchemist/alchemist.dart';
 import 'package:alchemist/src/blocked_text_image.dart';
 import 'package:alchemist/src/pumps.dart';
 import 'package:alchemist/src/utilities.dart';
@@ -164,6 +165,7 @@ abstract class GoldenTestAdapter {
     required Widget widget,
     required PumpAction pumpBeforeTest,
     required PumpWidget pumpWidget,
+    required CoreWidgetWrapper? coreWrapper,
   });
 
   /// Generates an image of the widget at the given [finder] with all text
@@ -223,6 +225,7 @@ class FlutterGoldenTestAdapter extends GoldenTestAdapter {
     required BoxConstraints constraints,
     required ThemeData theme,
     required Widget widget,
+    required CoreWidgetWrapper? coreWrapper,
     required PumpAction pumpBeforeTest,
     required PumpWidget pumpWidget,
   }) async {
@@ -238,31 +241,37 @@ class FlutterGoldenTestAdapter extends GoldenTestAdapter {
 
     await pumpWidget(
       tester,
-      MaterialApp(
-        key: rootKey,
-        theme: theme.stripTextPackages(),
-        debugShowCheckedModeBanner: false,
-        supportedLocales: const [Locale('en')],
-        builder: (context, _) {
-          return DefaultAssetBundle(
-            bundle: TestAssetBundle(),
-            child: Material(
-              type: MaterialType.transparency,
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: ColoredBox(
-                  color: theme.colorScheme.background,
-                  child: Padding(
-                    key: childKey,
-                    padding: const EdgeInsets.all(8),
-                    child: widget,
+      coreWrapper?.call(
+            DefaultAssetBundle(
+              key: childKey,
+              bundle: TestAssetBundle(),
+              child: widget,
+            ),
+            rootKey,
+          ) ??
+          MaterialApp(
+            key: rootKey,
+            theme: theme.stripTextPackages(),
+            debugShowCheckedModeBanner: false,
+            supportedLocales: const [Locale('en')],
+            builder: (context, _) => DefaultAssetBundle(
+              bundle: TestAssetBundle(),
+              child: Material(
+                type: MaterialType.transparency,
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: ColoredBox(
+                    color: theme.colorScheme.background,
+                    child: Padding(
+                      key: childKey,
+                      padding: const EdgeInsets.all(8),
+                      child: widget,
+                    ),
                   ),
                 ),
               ),
             ),
-          );
-        },
-      ),
+          ),
     );
 
     final shouldTryResize = !constraints.isTight;

--- a/lib/src/golden_test_runner.dart
+++ b/lib/src/golden_test_runner.dart
@@ -1,3 +1,4 @@
+import 'package:alchemist/src/golden_test.dart';
 import 'package:alchemist/src/golden_test_adapter.dart';
 import 'package:alchemist/src/interactions.dart';
 import 'package:alchemist/src/pumps.dart';
@@ -34,6 +35,7 @@ abstract class GoldenTestRunner {
     required WidgetTester tester,
     required Object goldenPath,
     required Widget widget,
+    CoreWidgetWrapper? coreWrapper,
     bool forceUpdate = false,
     bool obscureText = false,
     bool renderShadows = false,
@@ -59,6 +61,7 @@ class FlutterGoldenTestRunner extends GoldenTestRunner {
     required WidgetTester tester,
     required Object goldenPath,
     required Widget widget,
+    CoreWidgetWrapper? coreWrapper,
     bool forceUpdate = false,
     bool obscureText = false,
     bool renderShadows = false,
@@ -88,6 +91,7 @@ class FlutterGoldenTestRunner extends GoldenTestRunner {
         constraints: constraints,
         pumpBeforeTest: pumpBeforeTest,
         pumpWidget: pumpWidget,
+        coreWrapper: coreWrapper,
         widget: widget,
         theme: themeData.copyWith(
           textTheme: obscureText

--- a/test/src/golden_test_adapter_test.dart
+++ b/test/src/golden_test_adapter_test.dart
@@ -217,6 +217,7 @@ void main() {
             pumpBeforeTest: onlyPumpAndSettle,
             pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
+            coreWrapper: null,
           );
 
           expect(find.byType(GoldenTestGroup), findsOneWidget);
@@ -239,6 +240,7 @@ void main() {
             pumpBeforeTest: onlyPumpAndSettle,
             pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
+            coreWrapper: null,
           );
 
           expect(tester.binding.window.physicalSize, providedSize);
@@ -264,6 +266,7 @@ void main() {
             pumpBeforeTest: onlyPumpAndSettle,
             pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
+            coreWrapper: null,
           );
 
           final targetSize = tester.getSize(find.byKey(groupKey));
@@ -296,6 +299,7 @@ void main() {
             pumpBeforeTest: onlyPumpAndSettle,
             pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
+            coreWrapper: null,
           );
 
           final groupSize = tester.getSize(find.byKey(groupKey));
@@ -338,6 +342,7 @@ void main() {
             pumpBeforeTest: onlyPumpAndSettle,
             pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
+            coreWrapper: null,
           );
 
           expect(tester.binding.window.physicalSize, maxSize);
@@ -356,6 +361,7 @@ void main() {
           pumpBeforeTest: onlyPumpAndSettle,
           pumpWidget: onlyPumpWidget,
           widget: buildGroup(),
+          coreWrapper: null,
         );
 
         expect(tester.binding.window.textScaleFactor, 2.0);
@@ -382,6 +388,7 @@ void main() {
             pumpBeforeTest: onlyPumpAndSettle,
             pumpWidget: onlyPumpWidget,
             widget: buildGroup(),
+            coreWrapper: null,
           );
 
           expect(
@@ -423,6 +430,7 @@ void main() {
           pumpBeforeTest: (_) async => pumpBeforeTestCalled = true,
           pumpWidget: onlyPumpWidget,
           widget: buildGroup(),
+          coreWrapper: null,
         );
 
         expect(pumpBeforeTestCalled, isTrue);
@@ -441,6 +449,7 @@ void main() {
             pumpWidgetCalled = true;
           },
           widget: buildGroup(),
+          coreWrapper: null,
         );
 
         expect(pumpWidgetCalled, isTrue);

--- a/test/src/golden_test_runner_test.dart
+++ b/test/src/golden_test_runner_test.dart
@@ -89,6 +89,7 @@ void main() {
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
           pumpWidget: any(named: 'pumpWidget'),
           widget: any(named: 'widget'),
+          coreWrapper: any(named: 'coreWrapper'),
         ),
       ).thenAnswer((_) async {});
 
@@ -155,6 +156,7 @@ void main() {
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
           pumpWidget: any(named: 'pumpWidget'),
           widget: any(named: 'widget'),
+          coreWrapper: any(named: 'coreWrapper'),
         ),
       ).captured.first as ThemeData;
 
@@ -199,6 +201,7 @@ void main() {
           pumpBeforeTest: any(named: 'pumpBeforeTest'),
           pumpWidget: any(named: 'pumpWidget'),
           widget: any(named: 'widget'),
+          coreWrapper: any(named: 'coreWrapper'),
         ),
       ).captured.first as ThemeData;
 

--- a/test/src/golden_test_test.dart
+++ b/test/src/golden_test_test.dart
@@ -42,6 +42,7 @@ class FakeGoldenTestAdapter extends Mock implements GoldenTestAdapter {
     required PumpAction pumpBeforeTest,
     required PumpWidget pumpWidget,
     required Widget widget,
+    required CoreWidgetWrapper? coreWrapper,
   }) {
     return Future.value();
   }


### PR DESCRIPTION
## Description

The Core Wrapper allows to replace the default MaterialApp golden test wrapper. In this way, user is in full control of the golden test wrapper and can specify any core widget. For example, the CupertinoApp with some custom localisation can be used. If CoreWrapper is not passed, the default MaterialWrapper is used. 

## Type of Change

- [x ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
