### PR TITLE
ci: fix the title of the semantic PR job

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -3,7 +3,7 @@ name: Semantic PR
 on: [pull_request_target]
 
 jobs:
-  build:
+  validate_title:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title


### PR DESCRIPTION
## Description

Changing the semantic PR job's name from `build` to `validate_title` to clean up the status checks view

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
