### PR TITLE
fix: load fonts from other packages correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 0.3.4
-
-- fix: load fonts from other packages correctly
-
 # 0.3.3
 
 - chore: upgrade flutter to 2.10.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.4
+
+- fix: load fonts from other packages correctly
+
 # 0.3.3
 
 - chore: upgrade flutter to 2.10.4

--- a/lib/src/golden_test.dart
+++ b/lib/src/golden_test.dart
@@ -35,7 +35,7 @@ Future<void> loadFonts() async {
       .map((dynamic x) => x as Map<String, dynamic>);
 
   for (final entry in fontManifest) {
-    final family = entry['family'] as String;
+    final family = _truncateFontPackageName(entry['family'] as String);
 
     final fontAssets = [
       for (final fontAssetEntry in entry['fonts'] as List<dynamic>)
@@ -49,6 +49,19 @@ Future<void> loadFonts() async {
 
     await loader.load();
   }
+}
+
+/// Truncates the 'packages/.../' prefix from the font package name. This is
+/// needed to properly load fonts from other packages, such as Alchemist's
+/// included Roboto fonts.
+///
+/// If no prefix is found, the original string is returned.
+String _truncateFontPackageName(String fontFamily) {
+  if (!fontFamily.startsWith('packages/')) {
+    return fontFamily;
+  }
+
+  return fontFamily.split('/').skip(2).join('/');
 }
 
 /// Performs a Flutter widget test that compares against golden image.

--- a/lib/src/golden_test.dart
+++ b/lib/src/golden_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:alchemist/alchemist.dart';
 import 'package:alchemist/src/alchemist_test_variant.dart';
 import 'package:alchemist/src/golden_test_runner.dart';
+import 'package:alchemist/src/utilities.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -35,7 +36,7 @@ Future<void> loadFonts() async {
       .map((dynamic x) => x as Map<String, dynamic>);
 
   for (final entry in fontManifest) {
-    final family = _truncateFontPackageName(entry['family'] as String);
+    final family = (entry['family'] as String).stripFontFamilyPackageName();
 
     final fontAssets = [
       for (final fontAssetEntry in entry['fonts'] as List<dynamic>)
@@ -49,19 +50,6 @@ Future<void> loadFonts() async {
 
     await loader.load();
   }
-}
-
-/// Truncates the 'packages/.../' prefix from the font package name. This is
-/// needed to properly load fonts from other packages, such as Alchemist's
-/// included Roboto fonts.
-///
-/// If no prefix is found, the original string is returned.
-String _truncateFontPackageName(String fontFamily) {
-  if (!fontFamily.startsWith('packages/')) {
-    return fontFamily;
-  }
-
-  return fontFamily.split('/').skip(2).join('/');
 }
 
 /// Performs a Flutter widget test that compares against golden image.

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -133,10 +133,18 @@ extension GoldenTestTextStyleExtensions on TextStyle {
       decorationStyle: decorationStyle,
       decorationThickness: decorationThickness,
       debugLabel: debugLabel,
-      fontFamily: fontFamily?.replaceAll(RegExp(r'packages\/[^\/]*\/'), ''),
+      fontFamily: fontFamily?.stripFontFamilyPackageName(),
       fontFamilyFallback: fontFamilyFallback,
       overflow: overflow,
     );
+  }
+}
+
+/// Strips the package name from the given font family for use in golden tests.
+extension FontFamilyStringExtensions on String {
+  /// Strips the package name from this font family for use in golden tests.
+  String stripFontFamilyPackageName() {
+    return replaceAll(RegExp(r'packages\/[^\/]*\/'), '');
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: alchemist
 description: A support package that aims to make golden testing in Flutter
   easier and more streamlined.
-version: 0.3.3
+version: 0.3.4
 homepage: https://github.com/Betterment/alchemist
 repository: https://github.com/Betterment/alchemist
 
@@ -10,17 +10,17 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  equatable: ^2.0.2
+  equatable: ^2.0.3
   flutter:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  meta: ^1.3.0
+  meta: ^1.7.0
 
 dev_dependencies:
   mocktail: ^0.3.0
   mocktail_image_network: ^0.3.1
-  test: ^1.17.12
+  test: ^1.21.1
   very_good_analysis: ^3.0.0
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: alchemist
 description: A support package that aims to make golden testing in Flutter
   easier and more streamlined.
-version: 0.3.4
+version: 0.3.3
 homepage: https://github.com/Betterment/alchemist
 repository: https://github.com/Betterment/alchemist
 


### PR DESCRIPTION
## Description

This PR includes a fix for Alchemist clients that do not use a custom font, but instead rely on the default Roboto font to be loaded.

Includes a version bump to 0.3.4.

### Bug

When using Alchemist's platform tests out of the box without any additional theming configuration, the default font family Roboto will be used.

However, due to a bug in our font loading logic, this font was assigned to the font family name `"packages/alchemist/Roboto"` instead of simply `"Roboto"`. This causes golden tests to fail to find the Robot font and it fail-safes to Ahem, causing unreadable platform goldens.

Reported by @alestiago, I was able to reproduce this with a clean sample project. Currently undergoing more rigorous testing. I'd like to ask others to test this with their projects as well. 😄

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
