### PR TITLE
ci: add workflow that will upload code coverage after a merge to main

### DIFF
--- a/.github/workflows/post_merge.yaml
+++ b/.github/workflows/post_merge.yaml
@@ -1,0 +1,27 @@
+name: post-merge
+
+on:
+  push:
+    - branches: 'main'
+
+jobs:
+  upload_coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.0.0
+          cache: true
+
+      - name: Install Dependencies
+        run: flutter packages get
+
+      - name: Run tests
+        run: flutter test --no-pub --coverage --test-randomize-ordering-seed=random
+
+      - uses: codecov/codecov-action@v2
+        with:
+          files: coverage/lcov.info

--- a/.github/workflows/post_merge.yaml
+++ b/.github/workflows/post_merge.yaml
@@ -2,7 +2,8 @@ name: post-merge
 
 on:
   push:
-    - branches: 'main'
+    branches:
+      - 'main'
 
 jobs:
   upload_coverage:


### PR DESCRIPTION
## Description

I noticed on previous PRs that Codecov reports were not showing the diff in coverage compared to `main` because it couldn't find previously uploaded reports because we squash commits, therefore changing the sha on `main` and causing Codecov being unable to associate the commits on `main` with previous uploads. By uploading them for the latest sha on `main` it will now be able to find them.

I went with this approach as opposed to adding a `push` trigger to the `main` workflow because that one does `format` and `analyze` which we don't need to do.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
