### PR TITLE
fix: handle_flutter_error

### DIFF
--- a/lib/src/golden_test_runner.dart
+++ b/lib/src/golden_test_runner.dart
@@ -103,11 +103,15 @@ class FlutterGoldenTestRunner extends GoldenTestRunner {
           : finder;
 
       try {
+        FlutterError.onError = (FlutterErrorDetails errorDetails) {
+          throw TestFailure(errorDetails.exception.toString());
+        };
         await goldenTestAdapter.withForceUpdateGoldenFiles(
           forceUpdate: forceUpdate,
           callback:
               goldenTestAdapter.goldenFileExpectation(toMatch, goldenPath),
         );
+        FlutterError.onError = null;
         await cleanup?.call();
       } on TestFailure {
         rethrow;


### PR DESCRIPTION
## Description


Flutter LocalFileComparator compare method throw a FlutterError when the compare fail. This compare is used by matchesGoldenFile(). Because of that, some golden can fail without throw an error and be registered as failure.

<img width="710" alt="Capture d’écran 2022-09-30 à 16 59 26" src="https://user-images.githubusercontent.com/37028599/193298700-96287ae0-f47a-4670-8ad2-b4bacd294de0.png">

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
