### PR TITLE
docs: fix readme relative link (Separate local & CI tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Heavily inspired by [Ebay Motor's `golden_toolkit` package][golden_toolkit_pub],
 
 ### Feature Overview
 
-- 🤖 [Separate local & CI tests](#about-readable-tests-vs-ci-tests)
+- 🤖 [Separate local & CI tests](#about-platform-tests-vs-ci-tests)
 - 📝 [Declarative & terse testing API](#writing-the-test)
 - 📐 [Automatic file sizing](#automaticcustom-image-sizing)
 - 🔧 [Advanced configuration](#advanced-usage)


### PR DESCRIPTION
## Description

I noticed that the relative link for `Separate local & CI tests` entry under `Feature Overview` in README is not working. I created a PR to fix it since it's one of the first links in README and may be potentially clicked a lot. 

I've read the contribution guidelines, but I decided not to create an issue for it first, since this is a rather simple, non-invasive change. I can always create it, though.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
