### PR TITLE
fix: loading fonts from other packages

### DIFF
--- a/lib/src/golden_test.dart
+++ b/lib/src/golden_test.dart
@@ -38,11 +38,10 @@ Future<void> _setUpGoldenTests() async {
 Future<void> loadFonts() async {
   final bundle = rootBundle;
   final fontManifestString = await bundle.loadString('FontManifest.json');
-  final fontManifest = (json.decode(fontManifestString) as List<dynamic>)
-      .map((dynamic x) => x as Map<String, dynamic>);
+  final fontManifest = (json.decode(fontManifestString) as List<dynamic>).map((dynamic x) => x as Map<String, dynamic>);
 
   for (final entry in fontManifest) {
-    final family = (entry['family'] as String).stripFontFamilyPackageName();
+    final family = (entry['family'] as String).stripFontFamilyAlchemistPackageName();
 
     final fontAssets = [
       for (final fontAssetEntry in entry['fonts'] as List<dynamic>)

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -80,34 +80,33 @@ extension GoldenTestThemeDataExtensions on ThemeData {
   static const obscuredTextFontFamily = 'Ahem';
 
   /// Strips all text packages from this theme's [ThemeData.textTheme] for use
-  /// in golden tests using [GoldenTestTextStyleExtensions.stripPackage].
+  /// in golden tests using [GoldenTestTextStyleExtensions.stripAlchemistPackage].
   ///
   /// Only used internally and should not be used by consumers.
   @protected
   ThemeData stripTextPackages() {
     return copyWith(
       textTheme: textTheme.copyWith(
-        displayLarge: textTheme.displayLarge?.stripPackage(),
-        displayMedium: textTheme.displayMedium?.stripPackage(),
-        displaySmall: textTheme.displaySmall?.stripPackage(),
-        headlineMedium: textTheme.headlineMedium?.stripPackage(),
-        headlineSmall: textTheme.headlineSmall?.stripPackage(),
-        titleLarge: textTheme.titleLarge?.stripPackage(),
-        titleMedium: textTheme.titleMedium?.stripPackage(),
-        titleSmall: textTheme.titleSmall?.stripPackage(),
-        bodyLarge: textTheme.bodyLarge?.stripPackage(),
-        bodyMedium: textTheme.bodyMedium?.stripPackage(),
-        bodySmall: textTheme.bodySmall?.stripPackage(),
-        labelLarge: textTheme.labelLarge?.stripPackage(),
-        labelSmall: textTheme.labelSmall?.stripPackage(),
+        displayLarge: textTheme.displayLarge?.stripAlchemistPackage(),
+        displayMedium: textTheme.displayMedium?.stripAlchemistPackage(),
+        displaySmall: textTheme.displaySmall?.stripAlchemistPackage(),
+        headlineMedium: textTheme.headlineMedium?.stripAlchemistPackage(),
+        headlineSmall: textTheme.headlineSmall?.stripAlchemistPackage(),
+        titleLarge: textTheme.titleLarge?.stripAlchemistPackage(),
+        titleMedium: textTheme.titleMedium?.stripAlchemistPackage(),
+        titleSmall: textTheme.titleSmall?.stripAlchemistPackage(),
+        bodyLarge: textTheme.bodyLarge?.stripAlchemistPackage(),
+        bodyMedium: textTheme.bodyMedium?.stripAlchemistPackage(),
+        bodySmall: textTheme.bodySmall?.stripAlchemistPackage(),
+        labelLarge: textTheme.labelLarge?.stripAlchemistPackage(),
+        labelSmall: textTheme.labelSmall?.stripAlchemistPackage(),
       ),
       floatingActionButtonTheme: floatingActionButtonTheme.copyWith(
-        extendedTextStyle:
-            floatingActionButtonTheme.extendedTextStyle?.stripPackage(),
+        extendedTextStyle: floatingActionButtonTheme.extendedTextStyle?.stripAlchemistPackage(),
       ),
       dialogTheme: dialogTheme.copyWith(
-        titleTextStyle: dialogTheme.titleTextStyle?.stripPackage(),
-        contentTextStyle: dialogTheme.contentTextStyle?.stripPackage(),
+        titleTextStyle: dialogTheme.titleTextStyle?.stripAlchemistPackage(),
+        contentTextStyle: dialogTheme.contentTextStyle?.stripAlchemistPackage(),
       ),
     );
   }
@@ -135,7 +134,7 @@ extension GoldenTestTextStyleExtensions on TextStyle {
   /// Strips the package name from this text style's [TextStyle.fontFamily] for
   /// use in golden tests.
   @protected
-  TextStyle stripPackage() {
+  TextStyle stripAlchemistPackage() {
     return TextStyle(
       inherit: inherit,
       color: color,
@@ -158,7 +157,7 @@ extension GoldenTestTextStyleExtensions on TextStyle {
       decorationStyle: decorationStyle,
       decorationThickness: decorationThickness,
       debugLabel: debugLabel,
-      fontFamily: fontFamily?.stripFontFamilyPackageName(),
+      fontFamily: fontFamily?.stripFontFamilyAlchemistPackageName(),
       fontFamilyFallback: fontFamilyFallback,
       overflow: overflow,
     );
@@ -168,8 +167,8 @@ extension GoldenTestTextStyleExtensions on TextStyle {
 /// Strips the package name from the given font family for use in golden tests.
 extension FontFamilyStringExtensions on String {
   /// Strips the package name from this font family for use in golden tests.
-  String stripFontFamilyPackageName() {
-    return replaceAll(RegExp(r'packages\/[^\/]*\/'), '');
+  String stripFontFamilyAlchemistPackageName() {
+    return replaceAll(RegExp(r'packages\/alchemist\/'), '');
   }
 }
 

--- a/test/src/utilities_test.dart
+++ b/test/src/utilities_test.dart
@@ -93,9 +93,8 @@ to avoid unnecessary overhead.''',
   });
 
   group('GoldenTestThemeDataExtensions', () {
-    test('stripTextPackages remove package prefix from all textTheme styles',
-        () {
-      const fontFamilyBefore = 'packages/package_name/dir1/dir2';
+    test('stripTextPackages remove package prefix from all textTheme styles', () {
+      const fontFamilyBefore = 'packages/alchemist/dir1/dir2';
       const fontFamilyAfter = 'dir1/dir2';
 
       final base = ThemeData();
@@ -142,12 +141,12 @@ to avoid unnecessary overhead.''',
   });
 
   group('GoldenTestTextStyleExtensions', () {
-    test('stripPackage removes package prefix from style', () {
-      const fontFamilyBefore = 'packages/package_name/dir1/dir2';
+    test('stripAlchemistPackage removes package prefix from style', () {
+      const fontFamilyBefore = 'packages/alchemist/dir1/dir2';
       const fontFamilyAfter = 'dir1/dir2';
 
       const styleBefore = TextStyle(fontFamily: fontFamilyBefore);
-      final styleAfter = styleBefore.stripPackage();
+      final styleAfter = styleBefore.stripAlchemistPackage();
 
       expect(
         styleAfter,
@@ -162,16 +161,14 @@ to avoid unnecessary overhead.''',
 
   group('TestAssetBundle', () {
     setUp(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMessageHandler(
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         'flutter/assets',
         (message) async => message,
       );
     });
 
     tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMessageHandler(
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         'flutter/assets',
         null,
       );


### PR DESCRIPTION
## Description

Font rendering did not work when fonts are from another package. We are using a separate package for our styleguide including assets, textstyles and fonts... This change makes it possible.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
