### PR TITLE
feat: allow updating goldens on CI

### DIFF
--- a/.github/workflows/update_goldens.yaml
+++ b/.github/workflows/update_goldens.yaml
@@ -1,0 +1,61 @@
+name: Update Goldens
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to generate goldens from'
+        required: true
+permissions:
+  contents: write
+
+jobs:
+  update_goldens:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Validate branch input
+        run: |
+          BRANCH_PATTERN="^[a-zA-Z0-9/_.-]+$"
+
+          # Input string (branch name) to be validated
+          BRANCH_NAME=${{ inputs.branch}}
+
+          echo "Checking branch name: $BRANCH_NAME"
+
+          # Validate branch name against the regex pattern
+          if [[ $BRANCH_NAME =~ $BRANCH_PATTERN ]]; then
+              echo "Branch name is valid."
+              exit 0
+          else
+              echo "Branch name is invalid."
+              exit 1
+          fi
+
+      - name: Ensure branch is not main
+        if: ${{ github.event.inputs.branch == 'main' || github.event.inputs.branch == 'origin/main'}}
+        run: exit 1
+
+      - name: Checkout branch
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.13.0'
+          channel: 'stable'
+          cache: true
+
+      - name: Update Goldens
+        run: |
+          flutter test --update-goldens
+        continue-on-error: true
+
+      - name: Commit Changes
+        id: commit_changes
+        uses: stefanzweifel/git-auto-commit-action@12f68633e45c72459cd040c868605f2471c7f63b # v5.0.0
+        with:
+          commit_message: "chore: Updating Goldens"
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
## Description

As part of https://github.com/Betterment/alchemist/pull/118, we need to re-generate some goldens due to issues with Flutter 3.16 compatibility with existing goldens. See discussions on #103 and #104. However, generating these locally on MacOS to be _used_ by CI does not re-generate all of them, indicating a difference between MacOS and Linux results (this is commented on [here](https://github.com/Betterment/alchemist/issues/104#issuecomment-1888831326)).

This PR adds a workflow that would allow maintainers to run a workflow to re-generate goldens on a given branch. The branch input is validated as part of the workflow.

RE: who has access to this button, see [here](https://github.com/orgs/community/discussions/26622). Basically, collaborators have access to this button, which I think is OK. We also ensure we're not updating `main`, giving extra safety.

You can see a successful run [here](https://github.com/Betterment/alchemist/actions/runs/10797489428) which just so happened to run on my 3.16.0 PR and re-generate the _correct_ goldens as shown [here](https://github.com/Betterment/alchemist/compare/bt/3.16.0-update-goldens?expand=1).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
