### PR TITLE
fix: Could not override GoldenTestTheme

### DIFF
--- a/lib/alchemist.dart
+++ b/lib/alchemist.dart
@@ -7,6 +7,7 @@ export 'src/blocked_text_image.dart';
 export 'src/golden_test.dart';
 export 'src/golden_test_group.dart';
 export 'src/golden_test_scenario.dart';
+export 'src/golden_test_theme.dart';
 export 'src/host_platform.dart';
 export 'src/interactions.dart';
 export 'src/pumps.dart';

--- a/lib/src/alchemist_config.dart
+++ b/lib/src/alchemist_config.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:alchemist/alchemist.dart';
-import 'package:alchemist/src/golden_test_theme.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/src/golden_test.dart
+++ b/lib/src/golden_test.dart
@@ -176,6 +176,7 @@ Future<void> goldenTest(
         widget: builder(),
         globalConfigTheme: config.theme,
         variantConfigTheme: variantConfig.theme,
+        goldenTestTheme: config.goldenTestTheme,
         forceUpdate: config.forceUpdateGoldenFiles,
         obscureText: variantConfig.obscureText,
         renderShadows: variantConfig.renderShadows,

--- a/lib/src/golden_test_adapter.dart
+++ b/lib/src/golden_test_adapter.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:alchemist/alchemist.dart';
-import 'package:alchemist/src/golden_test_theme.dart';
 import 'package:alchemist/src/utilities.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/lib/src/golden_test_adapter.dart
+++ b/lib/src/golden_test_adapter.dart
@@ -389,6 +389,15 @@ class FlutterGoldenTestWrapper extends StatelessWidget {
       resolvedTheme = resolvedTheme.applyObscuredFontFamily();
     }
 
+    if (goldenTestTheme != null) {
+      resolvedTheme = resolvedTheme.copyWith(
+        extensions: [
+          ...resolvedTheme.extensions.values,
+          goldenTestTheme!,
+        ],
+      );
+    }
+
     return resolvedTheme.stripTextPackages();
   }
 
@@ -396,12 +405,7 @@ class FlutterGoldenTestWrapper extends StatelessWidget {
   Widget build(BuildContext context) {
     return _LocalizationWrapper(
       child: Theme(
-        data: _resolveThemeOf(context).copyWith(
-          extensions: [
-            ...Theme.of(context).extensions.values,
-            if (goldenTestTheme != null) goldenTestTheme!,
-          ],
-        ),
+        data: _resolveThemeOf(context),
         child: _NavigatorWrapper(
           child: child,
         ),

--- a/lib/src/golden_test_adapter.dart
+++ b/lib/src/golden_test_adapter.dart
@@ -245,6 +245,7 @@ class FlutterGoldenTestAdapter extends GoldenTestAdapter {
         obscureFont: obscureFont,
         globalConfigTheme: globalConfigTheme,
         variantConfigTheme: variantConfigTheme,
+        goldenTestTheme: goldenTestTheme,
         child: DefaultAssetBundle(
           bundle: TestAssetBundle(),
           child: Material(
@@ -324,6 +325,7 @@ class FlutterGoldenTestWrapper extends StatelessWidget {
     super.key,
     this.globalConfigTheme,
     this.variantConfigTheme,
+    this.goldenTestTheme,
     this.obscureFont = false,
     required this.child,
   });
@@ -337,6 +339,12 @@ class FlutterGoldenTestWrapper extends StatelessWidget {
   ///
   /// See [MaterialApp.theme] for more details.
   final ThemeData? variantConfigTheme;
+
+  /// The [GoldenTestTheme] to use when generating golden tests.
+  ///
+  /// If no [GoldenTestTheme] is provided, the default
+  /// [GoldenTestTheme.standard] will be used.
+  final GoldenTestTheme? goldenTestTheme;
 
   /// Whether the default font family of the resolved theme should be set to an
   /// obscured font.
@@ -388,7 +396,12 @@ class FlutterGoldenTestWrapper extends StatelessWidget {
   Widget build(BuildContext context) {
     return _LocalizationWrapper(
       child: Theme(
-        data: _resolveThemeOf(context),
+        data: _resolveThemeOf(context).copyWith(
+          extensions: [
+            ...Theme.of(context).extensions.values,
+            if (goldenTestTheme != null) goldenTestTheme!,
+          ],
+        ),
         child: _NavigatorWrapper(
           child: child,
         ),

--- a/lib/src/golden_test_group.dart
+++ b/lib/src/golden_test_group.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:alchemist/alchemist.dart';
 import 'package:alchemist/src/golden_test_scenario_constraints.dart';
-import 'package:alchemist/src/golden_test_theme.dart';
 import 'package:flutter/material.dart';
 
 /// A function that receives the index of a column in a table and returns the

--- a/lib/src/golden_test_group.dart
+++ b/lib/src/golden_test_group.dart
@@ -113,6 +113,7 @@ class GoldenTestGroup extends StatelessWidget {
     }
 
     final testTheme = Theme.of(context).extension<GoldenTestTheme>() ??
+        AlchemistConfig.current().goldenTestTheme ??
         GoldenTestTheme.standard();
 
     return GoldenTestScenarioConstraints(

--- a/lib/src/golden_test_group.dart
+++ b/lib/src/golden_test_group.dart
@@ -112,9 +112,8 @@ class GoldenTestGroup extends StatelessWidget {
       }
     }
 
-    final alchemistConfig = AlchemistConfig.current();
-    final testTheme =
-        alchemistConfig.goldenTestTheme ?? GoldenTestTheme.standard();
+    final testTheme = Theme.of(context).extension<GoldenTestTheme>() ??
+        GoldenTestTheme.standard();
 
     return GoldenTestScenarioConstraints(
       constraints: scenarioConstraints,

--- a/lib/src/golden_test_runner.dart
+++ b/lib/src/golden_test_runner.dart
@@ -30,6 +30,7 @@ abstract class GoldenTestRunner {
     required Widget widget,
     required ThemeData? globalConfigTheme,
     required ThemeData? variantConfigTheme,
+    required GoldenTestTheme? goldenTestTheme,
     bool forceUpdate = false,
     bool obscureText = false,
     bool renderShadows = false,

--- a/lib/src/golden_test_theme.dart
+++ b/lib/src/golden_test_theme.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 /// parts of golden tests controlled by Alchemist are consistent across
 /// Flutter SDK versions.
 /// {@endtemplate}
-class GoldenTestTheme {
+class GoldenTestTheme extends ThemeExtension<GoldenTestTheme> {
   /// {@macro golden_test_theme}
   GoldenTestTheme({
     required this.backgroundColor,
@@ -29,4 +29,30 @@ class GoldenTestTheme {
 
   /// The border color used to separate scenarios in a [GoldenTestGroup].
   final Color borderColor;
+
+  @override
+  ThemeExtension<GoldenTestTheme> copyWith({
+    Color? backgroundColor,
+    Color? borderColor,
+  }) {
+    return GoldenTestTheme(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      borderColor: borderColor ?? this.borderColor,
+    );
+  }
+
+  @override
+  ThemeExtension<GoldenTestTheme> lerp(
+    covariant ThemeExtension<GoldenTestTheme>? other,
+    double t,
+  ) {
+    if (other is! GoldenTestTheme) {
+      return this;
+    }
+    return GoldenTestTheme(
+      backgroundColor: Color.lerp(backgroundColor, other.backgroundColor, t) ??
+          backgroundColor,
+      borderColor: Color.lerp(borderColor, other.borderColor, t) ?? borderColor,
+    );
+  }
 }

--- a/test/src/golden_test_test.dart
+++ b/test/src/golden_test_test.dart
@@ -3,7 +3,6 @@ import 'dart:ui' as ui;
 import 'package:alchemist/alchemist.dart';
 import 'package:alchemist/src/golden_test_adapter.dart';
 import 'package:alchemist/src/golden_test_runner.dart';
-import 'package:alchemist/src/golden_test_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/test/src/golden_test_test.dart
+++ b/test/src/golden_test_test.dart
@@ -105,6 +105,7 @@ void main() {
           widget: any(named: 'widget'),
           globalConfigTheme: any(named: 'globalConfigTheme'),
           variantConfigTheme: any(named: 'variantConfigTheme'),
+          goldenTestTheme: any(named: 'goldenTestTheme'),
           forceUpdate: any(named: 'forceUpdate'),
           obscureText: any(named: 'obscureText'),
           renderShadows: any(named: 'renderShadows'),
@@ -140,10 +141,15 @@ void main() {
       final ciTheme = ThemeData.light().copyWith(primaryColor: Colors.green);
       final platformTheme =
           ThemeData.light().copyWith(primaryColor: Colors.yellow);
+      final goldenTestTheme = GoldenTestTheme(
+        backgroundColor: Colors.blueGrey,
+        borderColor: Colors.orange,
+      );
       const ciRenderShadows = true;
       final config = AlchemistConfig(
         forceUpdateGoldenFiles: false,
         theme: alchemistTheme,
+        goldenTestTheme: goldenTestTheme,
         ciGoldensConfig: CiGoldensConfig(
           theme: ciTheme,
           renderShadows: ciRenderShadows,
@@ -178,6 +184,7 @@ void main() {
           widget: widget,
           globalConfigTheme: alchemistTheme,
           variantConfigTheme: ciTheme,
+          goldenTestTheme: goldenTestTheme,
           forceUpdate: any(named: 'forceUpdate'),
           obscureText: any(named: 'obscureText'),
           renderShadows: ciRenderShadows,
@@ -196,6 +203,7 @@ void main() {
           widget: widget,
           globalConfigTheme: alchemistTheme,
           variantConfigTheme: platformTheme,
+          goldenTestTheme: goldenTestTheme,
           forceUpdate: any(named: 'forceUpdate'),
           obscureText: any(named: 'obscureText'),
           renderShadows: any(named: 'renderShadows'),

--- a/test/src/golden_test_theme_test.dart
+++ b/test/src/golden_test_theme_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:alchemist/src/golden_test_adapter.dart';
-import 'package:alchemist/src/golden_test_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
## Description

All our tests failed because the default GoldenTestTheme changed the background colour. The GoldenTestTheme cannot be overwritten as it is not exported via the barrel file.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
