### PR TITLE
fix!: use textScaler instead of a double

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ By default, Alchemist will simply pump the widget being tested using `tester.pum
 
 The `GoldenTestScenario.withTextScaleFactor` constructor allows a custom text scale factor value to be provided for a single scenario. This can be used to test text rendering at different sizes.
 
-To set a default scale factor for all scenarios within a test, the `goldenTest` function allows a default `textScaleFactor` to be provided, which defaults to `1.0`.
+To set a default scale factor for all scenarios within a test, the `goldenTest` function allows a default `textScaler` to be provided, which defaults to `TextScaler.linear(1.0)`.
 
 ### Resources
 

--- a/lib/src/golden_test_scenario.dart
+++ b/lib/src/golden_test_scenario.dart
@@ -38,17 +38,17 @@ class GoldenTestScenario extends StatelessWidget {
     this.constraints,
   });
 
-  /// Creates a [GoldenTestScenario] with a custom [textScaleFactor] that
+  /// Creates a [GoldenTestScenario] with a custom [textScaler] that
   /// applies a default scale of text to its child.
   GoldenTestScenario.withTextScaleFactor({
     super.key,
     required this.name,
-    required double textScaleFactor,
+    required TextScaler textScaler,
     required Widget child,
     this.constraints,
   }) : builder = _build(
           _CustomTextScaleFactor(
-            textScaleFactor: textScaleFactor,
+            textScaler: textScaler,
             child: child,
           ),
         );
@@ -96,27 +96,27 @@ class GoldenTestScenario extends StatelessWidget {
 }
 
 /// {@template _custom_text_scale_factor}
-/// An internal widget used to apply a default [textScaleFactor] to its [child].
+/// An internal widget used to apply a default [textScaler] to its [child].
 /// {@endtemplate}
 @protected
 class _CustomTextScaleFactor extends StatelessWidget {
   /// {@macro _custom_text_scale_factor}
   const _CustomTextScaleFactor({
-    required this.textScaleFactor,
+    required this.textScaler,
     required this.child,
   });
 
-  /// The default text scale factor to apply to the [child].
-  final double textScaleFactor;
+  /// The TextScaler will be applied to the [child].
+  final TextScaler textScaler;
 
-  /// The child widget to apply the [textScaleFactor] to.
+  /// The child widget to apply the [textScaler] to.
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(
-        textScaler: TextScaler.linear(textScaleFactor),
+        textScaler: textScaler,
       ),
       child: child,
     );

--- a/test/src/golden_test_scenario_test.dart
+++ b/test/src/golden_test_scenario_test.dart
@@ -40,8 +40,7 @@ void main() {
     });
 
     group('constraints', () {
-      testWidgets('when null defaults to inherited constraints',
-          (tester) async {
+      testWidgets('when null defaults to inherited constraints', (tester) async {
         const constraints = BoxConstraints(maxWidth: 400);
         final subject = buildSubject();
 
@@ -55,8 +54,7 @@ void main() {
         final findConstraints = find.ancestor(
           of: find.text('child'),
           matching: find.byWidgetPredicate(
-            (widget) =>
-                widget is ConstrainedBox && widget.constraints == constraints,
+            (widget) => widget is ConstrainedBox && widget.constraints == constraints,
           ),
         );
 
@@ -72,16 +70,14 @@ void main() {
         final findConstraints = find.ancestor(
           of: find.text('child'),
           matching: find.byWidgetPredicate(
-            (widget) =>
-                widget is ConstrainedBox && widget.constraints == constraints,
+            (widget) => widget is ConstrainedBox && widget.constraints == constraints,
           ),
         );
 
         expect(findConstraints, findsOneWidget);
       });
 
-      testWidgets('takes precedence over inherited constraints',
-          (tester) async {
+      testWidgets('takes precedence over inherited constraints', (tester) async {
         const constraints = BoxConstraints(maxWidth: 400);
         final subject = buildSubject(constraints: constraints);
 
@@ -95,8 +91,7 @@ void main() {
         final findConstraints = find.ancestor(
           of: find.text('child'),
           matching: find.byWidgetPredicate(
-            (widget) =>
-                widget is ConstrainedBox && widget.constraints == constraints,
+            (widget) => widget is ConstrainedBox && widget.constraints == constraints,
           ),
         );
 
@@ -128,10 +123,11 @@ void main() {
     });
 
     testWidgets(
-      '.withTextScaleFactor sets correct default text scale factor',
+      '.withTextScaleFactor sets correct default textScaler',
       (tester) async {
+        const textScaler = TextScaler.linear(2);
         final subject = GoldenTestScenario.withTextScaleFactor(
-          textScaleFactor: 2,
+          textScaler: textScaler,
           name: 'name',
           child: const Text('child'),
         );
@@ -153,7 +149,7 @@ void main() {
           isA<MediaQueryData>().having(
             (m) => m.textScaler,
             'textScaler',
-            const TextScaler.linear(2),
+            textScaler,
           ),
         );
       },

--- a/test/src/golden_test_scenario_test.dart
+++ b/test/src/golden_test_scenario_test.dart
@@ -40,7 +40,8 @@ void main() {
     });
 
     group('constraints', () {
-      testWidgets('when null defaults to inherited constraints', (tester) async {
+      testWidgets('when null defaults to inherited constraints',
+          (tester) async {
         const constraints = BoxConstraints(maxWidth: 400);
         final subject = buildSubject();
 
@@ -54,7 +55,8 @@ void main() {
         final findConstraints = find.ancestor(
           of: find.text('child'),
           matching: find.byWidgetPredicate(
-            (widget) => widget is ConstrainedBox && widget.constraints == constraints,
+            (widget) =>
+                widget is ConstrainedBox && widget.constraints == constraints,
           ),
         );
 
@@ -70,14 +72,16 @@ void main() {
         final findConstraints = find.ancestor(
           of: find.text('child'),
           matching: find.byWidgetPredicate(
-            (widget) => widget is ConstrainedBox && widget.constraints == constraints,
+            (widget) =>
+                widget is ConstrainedBox && widget.constraints == constraints,
           ),
         );
 
         expect(findConstraints, findsOneWidget);
       });
 
-      testWidgets('takes precedence over inherited constraints', (tester) async {
+      testWidgets('takes precedence over inherited constraints',
+          (tester) async {
         const constraints = BoxConstraints(maxWidth: 400);
         final subject = buildSubject(constraints: constraints);
 
@@ -91,7 +95,8 @@ void main() {
         final findConstraints = find.ancestor(
           of: find.text('child'),
           matching: find.byWidgetPredicate(
-            (widget) => widget is ConstrainedBox && widget.constraints == constraints,
+            (widget) =>
+                widget is ConstrainedBox && widget.constraints == constraints,
           ),
         );
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Give people more control over the textScaleFactor with an actual textScaler instead of the textScaleFactor double

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
