### PR TITLE
chore: prep 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.11.0
+
+## What's Changed
+* fix!: use textScaler instead of a double by @vanlooverenkoen in https://github.com/Betterment/alchemist/pull/131
+* feat!: Added nameTextStyle by @vanlooverenkoen in https://github.com/Betterment/alchemist/pull/132
+* fix: added configurable padding by @vanlooverenkoen in https://github.com/Betterment/alchemist/pull/133
+
+## New Contributors
+* @vanlooverenkoen made their first contribution in https://github.com/Betterment/alchemist/pull/131
+
+**Full Changelog**: https://github.com/Betterment/alchemist/compare/v0.10.0...v0.11.0
+
 # 0.10.0
 
 ## What's Changed
@@ -5,6 +17,9 @@
 * fix: Could not override GoldenTestTheme by @Brainyoo in https://github.com/Betterment/alchemist/pull/127
 * ci: channel compatibility workflow by @btrautmann in https://github.com/Betterment/alchemist/pull/123
 
+## :warning: Breaking Changes
+
+In https://github.com/Betterment/alchemist/pull/123 a `Padding` `Widget` was removed that impacted the outputted golden files. However, this `Padding` was made configurable in https://github.com/Betterment/alchemist/pull/133 so you can upgrade directly to `0.11.0` and set a `Padding` value of `const EdgeInsets.all(8)` to preserve the original padding value.
 
 **Full Changelog**: https://github.com/Betterment/alchemist/compare/v0.9.0...v0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * feat!: Added nameTextStyle by @vanlooverenkoen in https://github.com/Betterment/alchemist/pull/132
 * fix: added configurable padding by @vanlooverenkoen in https://github.com/Betterment/alchemist/pull/133
 
+## :warning: Breaking Changes
+
+https://github.com/Betterment/alchemist/pull/131 and https://github.com/Betterment/alchemist/pull/132 change the APIs of `GoldenTestScenario.withTextScaleFactor` and `GoldenTestTheme` respectively. If you are using these APIs, you will need to update your code to match the new API.
+
 ## New Contributors
 * @vanlooverenkoen made their first contribution in https://github.com/Betterment/alchemist/pull/131
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: alchemist
 description: A support package that aims to make golden testing in Flutter
   easier and more streamlined.
-version: 0.10.0
+version: 0.11.0
 homepage: https://github.com/Betterment/alchemist
 repository: https://github.com/Betterment/alchemist
 


### PR DESCRIPTION
## Description

Preps `0.11.0` release and adds a note RE: the breaking `Padding` change to the `0.10.0` release notes.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore
