### PR TITLE
ci: add branch-switching for beta channel

### DIFF
--- a/.github/workflows/check_compat.yaml
+++ b/.github/workflows/check_compat.yaml
@@ -15,7 +15,21 @@ jobs:
         channel: ['stable', 'beta']
 
     steps:
+      - name: Set branch based on Flutter channel
+        id: set-branch
+        run: |
+          if [[ "${{ matrix.channel }}" == "stable" ]]; then
+            echo "branch=main" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.channel }}" == "beta" ]]; then
+            echo "branch=beta" >> $GITHUB_OUTPUT
+          else
+            echo "Unknown Flutter channel: ${{ matrix.channel }}"
+            exit 1
+          fi
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ steps.set-branch.outputs.branch }}
 
       - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1 # v2.16.0
         with:


### PR DESCRIPTION
## Description

This PR adds a step in the `check_compat` workflow that switches to the `beta` branch when testing `beta` channel of Flutter. This would unblock folks tryin to utilize the `beta` channel without us needing to bump the minimum constraint (yet) or maintain a separate release pipeline that would allow us to be compatible on both channels.

**Note:** I tested this here and it passed: https://github.com/Betterment/alchemist/actions/runs/14068129507

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
