### PR TITLE
Add an alias for same-package fonts

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_test:
     sdk: flutter
   meta: ^1.7.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   mocktail: ^0.3.0


### PR DESCRIPTION
## Description

Added an alias for same-package fonts to support running golden tests in packages (e.g. design systems).

Fixes #113 

The specified `package:yaml` lower version constraint is equal to `package:yaml` [pinned in Flutter 3.16](https://github.com/flutter/flutter/blob/db7ef5bf9f59442b0e200a90587e8fa5e0c6336a/packages/flutter/pubspec.yaml#L75) (min. supported version) to avoid version conflicts.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
