### PR TITLE
fix: add RSuperellipse methods for Flutter 3.32 compat

### DIFF
--- a/lib/src/blocked_text_image.dart
+++ b/lib/src/blocked_text_image.dart
@@ -101,6 +101,10 @@ class BlockedTextCanvasAdapter implements Canvas {
       parent.clipRect(rect, clipOp: clipOp, doAntiAlias: doAntiAlias);
 
   @override
+  void clipRSuperellipse(ui.RSuperellipse rsuperellipse, {bool doAntiAlias = true}) =>
+      parent.clipRSuperellipse(rsuperellipse, doAntiAlias: doAntiAlias);
+  
+  @override
   void drawArc(
     ui.Rect rect,
     double startAngle,
@@ -224,6 +228,10 @@ class BlockedTextCanvasAdapter implements Canvas {
   void drawRect(ui.Rect rect, ui.Paint paint) => parent.drawRect(rect, paint);
 
   @override
+  void drawRSuperellipse(ui.RSuperellipse rsuperellipse, ui.Paint paint) =>
+      parent.drawRSuperellipse(rsuperellipse, paint);
+      
+  @override
   void drawShadow(
     ui.Path path,
     ui.Color color,
@@ -279,4 +287,5 @@ class BlockedTextCanvasAdapter implements Canvas {
 
   @override
   void restoreToCount(int count) => parent.restoreToCount(count);
+
 }


### PR DESCRIPTION
## Description

Alchemist fails to build with Flutter 3.32. Error is in footer. Two new methods on Canvas for superellipse shapes are implemented to fix the error.

Tested by using this in my pubspec.yaml and confirming tests pass:
```
  alchemist:
    git:
      url: https://github.com/telosnex/alchemist
      ref: main
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


## Error
```
  Failed to load "/Users/jpo/dev/telosnex/test/mcp/tools/filesystem/read_multiple_files_golden_test.dart":
  Compilation failed for testPath=/Users/jpo/dev/telosnex/test/mcp/tools/filesystem/read_multiple_files_golden_test.dart: ../../.pub-cache/hosted/pub.dev/alchemist-0.11.0/lib/src/blocked_text_image.dart:65:7: Error: The non-abstract class 'BlockedTextCanvasAdapter' is missing implementations for these members:
   - Canvas.clipRSuperellipse
   - Canvas.drawRSuperellipse
  Try to either
   - provide an implementation,
   - inherit an implementation from a superclass or mixin,
   - mark the class as abstract, or
   - provide a 'noSuchMethod' implementation.
  
  class BlockedTextCanvasAdapter implements Canvas {
        ^^^^^^^^^^^^^^^^^^^^^^^^
  org-dartlang-sdk:///flutter/lib/ui/painting.dart:5910:8: Context: 'Canvas.clipRSuperellipse' is defined here.
    void clipRSuperellipse(RSuperellipse rsuperellipse, {bool doAntiAlias = true});
         ^^^^^^^^^^^^^^^^^
  org-dartlang-sdk:///flutter/lib/ui/painting.dart:6040:8: Context: 'Canvas.drawRSuperellipse' is defined here.
    void drawRSuperellipse(RSuperellipse rsuperellipse, Paint paint);
         ^^^^^^^^^^^^^^^^^
```