### PR TITLE
fix: fontVariations is missing

### DIFF
--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -129,31 +129,8 @@ extension GoldenTestTextStyleExtensions on TextStyle {
   /// use in golden tests.
   @protected
   TextStyle stripAlchemistPackage() {
-    return TextStyle(
-      inherit: inherit,
-      color: color,
-      backgroundColor: backgroundColor,
-      fontSize: fontSize,
-      fontWeight: fontWeight,
-      fontStyle: fontStyle,
-      letterSpacing: letterSpacing,
-      wordSpacing: wordSpacing,
-      textBaseline: textBaseline,
-      height: height,
-      leadingDistribution: leadingDistribution,
-      locale: locale,
-      foreground: foreground,
-      background: background,
-      shadows: shadows,
-      fontFeatures: fontFeatures,
-      decoration: decoration,
-      decorationColor: decorationColor,
-      decorationStyle: decorationStyle,
-      decorationThickness: decorationThickness,
-      debugLabel: debugLabel,
+    return copyWith(
       fontFamily: fontFamily?.stripFontFamilyAlchemistPackageName(),
-      fontFamilyFallback: fontFamilyFallback,
-      overflow: overflow,
     );
   }
 }


### PR DESCRIPTION
## Description

Variable Fonts are not properly rendered on Golden tests.
It seems like the `fontVariations` property is missing in the `stripAlchemistPackage()` function. 

## Type of Change

Replaced `return TextStyle(...)` with `return copyWith(...)` which sorts out the bug and maintains stability in case Flutter changes the signature of `TextStyle`.

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
