### PR TITLE
feat: Add wrapper parameter to `goldenTest` function

### DIFF
--- a/example/lib/widgets/date_text.dart
+++ b/example/lib/widgets/date_text.dart
@@ -1,0 +1,16 @@
+import 'package:clock/clock.dart';
+import 'package:flutter/material.dart';
+
+class DateText extends StatelessWidget {
+  const DateText({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      clock.now().toIso8601String(),
+      textAlign: TextAlign.center,
+    );
+  }
+}

--- a/example/lib/widgets/widgets.dart
+++ b/example/lib/widgets/widgets.dart
@@ -1,2 +1,3 @@
 export 'contact_list_tile.dart';
+export 'date_text.dart';
 export 'red_button.dart';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
+  clock: ^1.1.2
   flutter:
     sdk: flutter
 

--- a/example/test/widgets/custom_wrapper_golden_test.dart
+++ b/example/test/widgets/custom_wrapper_golden_test.dart
@@ -1,0 +1,25 @@
+import 'package:alchemist/alchemist.dart';
+import 'package:clock/clock.dart';
+import 'package:example/widgets/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Custom Wrapper Golden Tests', () {
+    goldenTest(
+      'renders correctly',
+      fileName: 'custom_wrapper',
+      testWrapper: (test) async => withClock<void>(
+        Clock.fixed(DateTime.utc(2025, 9, 10)),
+        test,
+      ),
+      builder: () => GoldenTestGroup(
+        children: [
+          GoldenTestScenario(
+            name: 'now',
+            child: const DateText(),
+          ),
+        ],
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Possible fix of the https://github.com/Betterment/alchemist/issues/86. The cause of the issue is that we need to wrap up the code of the test body which is launched inside another zone in custom zone. There is no strict way in the current method signature to pass the wrapper.

The proposed solution from the thread

```dart
              pumpBeforeTest: (tester) async {
                await withClock(
                  clock ?? Clock.fixed(DateTime(2025, 12, 10)),
                  () async => pumpBeforeTest(tester),
                );
              },
              pumpWidget: (tester, widget) async {
                await withClock(
                  clock ?? Clock.fixed(DateTime(2025, 12, 10)),
                  () async => tester.pumpWidget(widget),
                );
              },
```

is not good enough because we have to wrap up the next pumps as well. It is more just like a proposal but this one is working on my end. I am not sure what kind of tests I can (should) add for this tweak.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
